### PR TITLE
Allow optional GUI via build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # RED-CODEX
+
+## Utilisation
+
+Pour lancer la version console :
+
+```sh
+go run .
+```
+
+Pour accéder à l'interface graphique (option 7), le fichier `gui_ebiten.go` nécessite un environnement graphique et doit être compilé avec le tag de build `gui` :
+
+```sh
+go run -tags gui .
+```
+

--- a/gui_ebiten.go
+++ b/gui_ebiten.go
@@ -1,3 +1,6 @@
+//go:build gui
+// +build gui
+
 package main
 
 import (

--- a/gui_stub.go
+++ b/gui_stub.go
@@ -1,0 +1,12 @@
+//go:build !gui
+// +build !gui
+
+package main
+
+import "fmt"
+
+// LaunchGUI is a stub when the GUI build tag is not set.
+func LaunchGUI() {
+    fmt.Println("Interface graphique indisponible. Recompilez avec le tag '-tags gui' et assurez-vous qu'un environnement graphique est présent.")
+}
+


### PR DESCRIPTION
## Summary
- Ensure GUI code only builds with the `gui` tag to avoid display errors
- Provide stubbed `LaunchGUI` when the GUI tag isn't used
- Document how to run the GUI in the README

## Testing
- `go build ./...`
- `go build -tags gui ./...`
- `go run .` (saisie interactive jusqu'à l'option 7)

------
https://chatgpt.com/codex/tasks/task_e_68c823b8c6d483228eef0166d5651bad